### PR TITLE
Adds article group into the blog card output

### DIFF
--- a/canonicalwebteam/blog/logic.py
+++ b/canonicalwebteam/blog/logic.py
@@ -52,7 +52,7 @@ def replace_images_with_cloudinary(content):
 def transform_article(
     article, featured_image=None, author=None, optimise_images=False
 ):
-    """Transform article to include featured image, human readable
+    """Transform article to include featured image, a group, human readable
     date and a stipped version of the excerpt
 
     :param article: The raw article object
@@ -87,6 +87,8 @@ def transform_article(
         article["excerpt"]["raw"] = "".join(
             [raw_article_start, raw_article_end, " […]"]
         )
+    if "group" in article and len(article["group"]) > 0:
+        article["group"] = article["group"][0]
 
     if (
         optimise_images

--- a/canonicalwebteam/blog/views.py
+++ b/canonicalwebteam/blog/views.py
@@ -21,6 +21,7 @@ def build_blueprint(blog_title, tags_id, tag_name):
             return flask.abort(502)
 
         category_cache = {}
+        group_cache = {}
 
         for article in articles:
             try:
@@ -39,6 +40,10 @@ def build_blueprint(blog_title, tags_id, tag_name):
                 if category_id not in category_cache:
                     category_cache[category_id] = {}
 
+            group_id = article["group"][0]
+            if group_id not in group_cache:
+                group_cache[group_id] = {}
+
             article = logic.transform_article(
                 article, featured_image=featured_image, author=author
             )
@@ -51,11 +56,20 @@ def build_blueprint(blog_title, tags_id, tag_name):
 
             category_cache[key] = resolved_category
 
+        for key, group in group_cache.items():
+            try:
+                resolved_group = api.get_group_by_id(key)
+            except Exception:
+                resolved_group = None
+
+            group_cache[key] = resolved_group
+
         context = {
             "current_page": page_param,
             "total_pages": int(total_pages),
             "articles": articles,
             "used_categories": category_cache,
+            "groups": group_cache,
         }
 
         return flask.render_template("blog/index.html", **context)

--- a/canonicalwebteam/blog/wordpress_api.py
+++ b/canonicalwebteam/blog/wordpress_api.py
@@ -83,6 +83,14 @@ def get_categories():
     return process_response(response)
 
 
+def get_group_by_id(id):
+    url = "".join([API_URL, "/group/", str(id)])
+
+    response = api_session.get(url)
+
+    return process_response(response)
+
+
 def get_category_by_id(id):
     url = "".join([API_URL, "/categories/", str(id)])
 


### PR DESCRIPTION
# Done
In order to display the correct styling for the different article groups we need to pass the group through to the template.
This PR resolves the group name for any given article and then applies those in the template.

# QA

Here is a screenshot of the updated plugin used on jp.ubuntu.com
![image](https://user-images.githubusercontent.com/2843450/53011498-6b07d880-3438-11e9-9c4e-bb318a4fd482.png)
